### PR TITLE
Fix TypeError on saving new file

### DIFF
--- a/app/projects/[id]/edit/page.tsx
+++ b/app/projects/[id]/edit/page.tsx
@@ -58,10 +58,13 @@ export default function EditProjectPage() {
     if (!project) return
 
     try {
+      // Remove timestamp fields from the data sent to the API
+      const { updatedAt, ...projectData } = project
+      
       const response = await fetch(`/api/projects/${projectId}`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(project),
+        body: JSON.stringify(projectData),
       })
 
       if (!response.ok) {

--- a/lib/db/index.ts
+++ b/lib/db/index.ts
@@ -42,9 +42,12 @@ export async function createProject(data: Omit<typeof schema.projects.$inferInse
 }
 
 export async function updateProject(id: number, data: Partial<typeof schema.projects.$inferInsert>) {
+  // Remove timestamp fields from incoming data to avoid conflicts
+  const { createdAt, updatedAt, ...cleanData } = data;
+  
   const result = await db
     .update(schema.projects)
-    .set({ ...data, updatedAt: new Date() })
+    .set({ ...cleanData, updatedAt: new Date() })
     .where(sql`id = ${id}`)
     .returning();
   return result[0];


### PR DESCRIPTION
The `TypeError: e.toISOString is not a function` occurred because timestamp fields like `updatedAt` were passed as strings to the database layer, which expected `Date` objects for `toISOString()` calls.

To resolve this:
*   In `lib/db/index.ts`, the `updateProject` function was modified. It now destructures `createdAt` and `updatedAt` from the input `data`, ensuring only clean data is passed to Drizzle ORM and `updatedAt` is explicitly set to `new Date()`. This prevents string timestamps from reaching the database.
*   In `app/projects/[id]/edit/page.tsx`, the form submission handler was updated. It now destructures `updatedAt` from the `project` object before sending the data to the API. This aligns with best practices by preventing the frontend from sending server-managed timestamp fields.

These changes ensure `updatedAt` is correctly handled as a `Date` object by the database, resolving the error.